### PR TITLE
Heuristic dissector

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,19 +176,22 @@ Currently supported settings are as follows:
 1. TCP/UDP port selection.
 2. (Experimental) Message decompression.
 
-> [!WARNING] Zenoh dissector does not support packet captures that mix compressed and uncompressed
-> messages. Message decompression should be enabled if and only if all Zenoh messages are
-> compressed. If you see a message that reads "Failed to decode possibly due to the experimental
-> compression preference", this might indicate that some Zenoh messages are not compressed, while
-> the dissector is configured to decode them as compressed messages (or vice versa).
+> [!WARNING]
+> Zenoh dissector does not support packet captures that mix compressed and uncompressed messages.
+> Message decompression should be enabled if and only if all Zenoh messages are compressed. If you
+> see a message that reads "Failed to decode possibly due to the experimental compression
+> preference", this might indicate that some Zenoh messages are not compressed, while the dissector
+> is configured to decode them as compressed messages (or vice versa).
 
 3. (Experimental) Heuristic dissector. This setting is not present in `Edit > Preferences >
 Protocols > Zenoh` but instead in `Analyze > Enabled Protocols`. Under `Zenoh`, the two heuristic
 dissectors `zenoh_tcp_heur` (Zenoh over TCP) and `zenoh_udp_heur` (Zenoh over UDP) can be enabled by
-switching their respective checkboxes. When enabled, Zenoh dissector will attempt to decode all TCP
-and UDP packets as Zenoh messages. Note that this might be performance-intensive and could
-theoretically even lead to decoding non-Zenoh messages. For these reasons, the heuristic dissector
-is disabled by default.
+switching their respective checkboxes. 
+
+> [!IMPORTANT]
+> When enabled, Zenoh dissector will attempt to decode all TCP and UDP packets as Zenoh messages.
+> Note that this might be performance-intensive and could theoretically even lead to decoding
+> non-Zenoh messages. For these reasons, the heuristic dissector is disabled by default.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Zenoh` or by right clicking a Zenoh packet and selecting `Protocol Preferences >
 
 Currently supported settings are as follows:
 
-1. TCP/UDP port selection.
-2. (Experimental) Message decompression.
+- TCP/UDP port selection.
+- (Experimental) Message decompression.
 
 > [!WARNING]
 > Zenoh dissector does not support packet captures that mix compressed and uncompressed messages.
@@ -183,10 +183,10 @@ Currently supported settings are as follows:
 > preference", this might indicate that some Zenoh messages are not compressed, while the dissector
 > is configured to decode them as compressed messages (or vice versa).
 
-3. (Experimental) Heuristic dissector. This setting is not present in `Edit > Preferences >
-Protocols > Zenoh` but instead in `Analyze > Enabled Protocols`. Under `Zenoh`, the two heuristic
-dissectors `zenoh_tcp_heur` (Zenoh over TCP) and `zenoh_udp_heur` (Zenoh over UDP) can be enabled by
-switching their respective checkboxes. 
+- (Experimental) Heuristic dissector. This setting is not present in `Edit > Preferences > Protocols > Zenoh`
+  but instead in `Analyze > Enabled Protocols`. Under the `Zenoh` protocol,
+  the two heuristic dissectors `zenoh_tcp_heur` (Zenoh over TCP) and `zenoh_udp_heur` (Zenoh over UDP)
+  can be enabled by switching their respective checkboxes.
 
 > [!IMPORTANT]
 > When enabled, Zenoh dissector will attempt to decode all TCP and UDP packets as Zenoh messages.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ We currently support
   > [!WARNING]
   > If you saw a message like "Failed to decode possibly due to the experimental compression preference.",
   those messages might not be compressed, please disable the compression preference to properly decode them.
+- (Experimental) Heuristic dissector: when enabled, zenoh-dissector will attempt to decode all TCP
+  and UDP packets as Zenoh messages. Note that this might be performance-intensive and could
+  theoretically lead to decoding non-Zenoh messages.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -168,18 +168,18 @@ Take the pub/sub as a example. One can check [here](https://github.com/eclipse-z
 
 ### Preferences
 
-One can  change the setting either via Edit > Preferences > Protocols > Zenoh or by a mouse right click > Protocol Preferneces > ZenohProtocols on any packet of zenoh protocol.
+One can change the setting either via Edit > Preferences > Protocols > Zenoh or by a mouse right click > Protocol Preferneces > ZenohProtocols on any packet of zenoh protocol.
 
 We currently support
 
-- TCP/UDP Port selection.
+- TCP/UDP port selection.
 - (Experimental) Message decompression.
-  > [!WARNING]
-  > If you saw a message like "Failed to decode possibly due to the experimental compression preference.",
-  those messages might not be compressed, please disable the compression preference to properly decode them.
-- (Experimental) Heuristic dissector: when enabled, zenoh-dissector will attempt to decode all TCP
-  and UDP packets as Zenoh messages. Note that this might be performance-intensive and could
-  theoretically lead to decoding non-Zenoh messages.
+> [!WARNING]
+> If you saw a message like "Failed to decode possibly due to the experimental compression preference.",
+those messages might not be compressed, please disable the compression preference to properly decode them.
+- (Experimental) Heuristic dissector (To enable it: Analyze > Enabled Protocols > zenoh_tcp_heur & zenoh_udp_heur).
+When enabled, zenoh-dissector will attempt to decode all TCP and UDP packets as Zenoh messages.
+Note that this might be performance-intensive and could theoretically lead to decoding non-Zenoh messages.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -168,20 +168,27 @@ Take the pub/sub as a example. One can check [here](https://github.com/eclipse-z
 
 ### Preferences
 
-One can change the setting either via Edit > Preferences > Protocols > Zenoh or by a mouse right click > Protocol Preferneces > ZenohProtocols on any packet of zenoh protocol.
+Zenoh dissector's settings can be changed via the menu bar through `Edit > Preferences > Protocols >
+Zenoh` or by right clicking a Zenoh packet and selecting `Protocol Preferences > ZenohProtocol`.
 
-We currently support
+Currently supported settings are as follows:
 
-- TCP/UDP port selection.
-- (Experimental) Message decompression.
+1. TCP/UDP port selection.
+2. (Experimental) Message decompression.
 
-> [!WARNING]
-> If you saw a message like "Failed to decode possibly due to the experimental compression preference.",
-those messages might not be compressed, please disable the compression preference to properly decode them.
+> [!WARNING] Zenoh dissector does not support packet captures that mix compressed and uncompressed
+> messages. Message decompression should be enabled if and only if all Zenoh messages are
+> compressed. If you see a message that reads "Failed to decode possibly due to the experimental
+> compression preference", this might indicate that some Zenoh messages are not compressed, while
+> the dissector is configured to decode them as compressed messages (or vice versa).
 
-- (Experimental) Heuristic dissector (To enable it: Analyze > Enabled Protocols > zenoh_tcp_heur & zenoh_udp_heur).
-When enabled, zenoh-dissector will attempt to decode all TCP and UDP packets as Zenoh messages.
-Note that this might be performance-intensive and could theoretically lead to decoding non-Zenoh messages.
+3. (Experimental) Heuristic dissector. This setting is not present in `Edit > Preferences >
+Protocols > Zenoh` but instead in `Analyze > Enabled Protocols`. Under `Zenoh`, the two heuristic
+dissectors `zenoh_tcp_heur` (Zenoh over TCP) and `zenoh_udp_heur` (Zenoh over UDP) can be enabled by
+switching their respective checkboxes. When enabled, Zenoh dissector will attempt to decode all TCP
+and UDP packets as Zenoh messages. Note that this might be performance-intensive and could
+theoretically even lead to decoding non-Zenoh messages. For these reasons, the heuristic dissector
+is disabled by default.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ We currently support
 
 - TCP/UDP port selection.
 - (Experimental) Message decompression.
+
 > [!WARNING]
 > If you saw a message like "Failed to decode possibly due to the experimental compression preference.",
 those messages might not be compressed, please disable the compression preference to properly decode them.
+
 - (Experimental) Heuristic dissector (To enable it: Analyze > Enabled Protocols > zenoh_tcp_heur & zenoh_udp_heur).
 When enabled, zenoh-dissector will attempt to decode all TCP and UDP packets as Zenoh messages.
 Note that this might be performance-intensive and could theoretically lead to decoding non-Zenoh messages.

--- a/zenoh-dissector/src/lib.rs
+++ b/zenoh-dissector/src/lib.rs
@@ -207,7 +207,7 @@ unsafe extern "C" fn register_handoff() {
         epan_sys::heur_dissector_add(
             nul_terminated_str("tcp").unwrap(),
             Some(dissect_heur),
-            nul_terminated_str("Zenoh over TCP Heuristic").unwrap(),
+            nul_terminated_str("Zenoh over TCP (heuristic)").unwrap(),
             nul_terminated_str("zenoh_tcp_heur").unwrap(),
             proto_id,
             epan_sys::heuristic_enable_e_HEURISTIC_DISABLE,
@@ -215,7 +215,7 @@ unsafe extern "C" fn register_handoff() {
         epan_sys::heur_dissector_add(
             nul_terminated_str("udp").unwrap(),
             Some(dissect_heur),
-            nul_terminated_str("Zenoh over UDP Heuristic").unwrap(),
+            nul_terminated_str("Zenoh over UDP (heuristic)").unwrap(),
             nul_terminated_str("zenoh_udp_heur").unwrap(),
             proto_id,
             epan_sys::heuristic_enable_e_HEURISTIC_DISABLE,

--- a/zenoh-dissector/src/lib.rs
+++ b/zenoh-dissector/src/lib.rs
@@ -406,13 +406,11 @@ unsafe extern "C" fn dissect_heur(
 ) -> bool {
     if !ENABLE_HEURISTIC_DISSECTOR {
         false
+    } else if let Ok(summary) = try_dissect_main(tvb, pinfo, tree, data).0 {
+        show_summary(pinfo, summary);
+        true
     } else {
-        if let Ok(summary) = try_dissect_main(tvb, pinfo, tree, data).0 {
-            show_summary(pinfo, summary);
-            true
-        } else {
-            false
-        }
+        false
     }
 }
 

--- a/zenoh-dissector/src/lib.rs
+++ b/zenoh-dissector/src/lib.rs
@@ -232,7 +232,7 @@ unsafe extern "C" fn register_handoff() {
             epan_sys::heuristic_enable_e_HEURISTIC_ENABLE,
         );
 
-        log::info!("Zenoh dissector is registered for TCP and UDP at port 7447");
+        log::info!("Zenoh dissector is registered for TCP port {TCP_PORT} and UDP port {UDP_PORT}");
         log::info!("Zenoh heuristic dissector is registered for TCP and UDP");
         log::info!(
             "Zenoh heuristic dissector is {}",


### PR DESCRIPTION
This adds a [heuristic dissector](https://www.wireshark.org/docs/wsar_html/group__packet.html#gac1f89fb22ed3dd53cb3aecbc7b87a528) that tries to parse TCP and UDP packets on all ports.

This offers an improved UX; currently the Wireshark UI forces us to decode packets _port by port_, which is tedious and silly for systems with many nodes.

~~The exiting preferences-based dissector could be removed in the future. We can also offer a preferences setting for disabling the heuristic dissector.~~ The preference was added in cb883a876858227de6a9778cfe7103f737c41ab4.

For now, I'm more interested in shipping this.