### PR TITLE
fix: scheduled workflow runs don't use default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         uses: eclipse-zenoh/ci/create-release-branch@main
         with:
           repo: ${{ github.repository }}
-          live-run: ${{ inputs.live-run }}
+          live-run: ${{ inputs.live-run || false }}
           version: ${{ inputs.version }}
           branch: ${{ inputs.branch }}
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
@@ -63,7 +63,7 @@ jobs:
       - uses: eclipse-zenoh/ci/bump-crates@main
         with:
           repo: ${{ github.repository }}
-          live-run: ${{ inputs.live-run }}
+          live-run: ${{ inputs.live-run || false }}
           version: ${{ steps.create-release-branch.outputs.version }}
           branch: ${{ steps.create-release-branch.outputs.branch }}
           bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '^$' }}


### PR DESCRIPTION
The scheduled release workflow doesn't use the default: false value for live-run, so add it here.

See https://github.com/eclipse-zenoh/zenoh-dissector/actions/runs/12738262858/job/35500327892