### PR TITLE
ci: use nightly wireshark PPA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt install -y software-properties-common
-          sudo add-apt-repository -y ppa:wireshark-dev/stable
+          sudo add-apt-repository -y ppa:wireshark-dev/nightly
           sudo apt install -y wireshark-dev
           sudo apt install -y --allow-change-held-packages wireshark
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt install -y software-properties-common
-          sudo add-apt-repository -y ppa:wireshark-dev/stable
+          sudo add-apt-repository -y ppa:wireshark-dev/nightly
           sudo apt install -y wireshark-dev
           sudo apt install -y --allow-change-held-packages wireshark
 


### PR DESCRIPTION
Currently stable wireshark PPA is publishing a version of `libwireshark-dev` (`4.4.6-2~ubuntu24.04.0~ppa1`) that depends on `libgio-2.0-dev` but that package doesn't exist for Ubuntu 24.04 The package in nightly (`4.5.0-0~202504240019~ubuntu24.04.1`) doesn't have that dependency.