### PR TITLE
ci: install cargo components for macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install rust components
+        run: |
+          rustup component add rustfmt clippy
+
       - name: Code format check
         run: cargo fmt -- --check
 


### PR DESCRIPTION
Fix: https://github.com/eclipse-zenoh/zenoh-dissector/actions/runs/15483908443/job/43594577633