### PR TITLE
ci: pass toolchain input to bump-crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '^$' }}
           bump-deps-version: ${{ inputs.zenoh-version }}
           bump-deps-branch: ${{ inputs.zenoh-version && format('release/{0}', inputs.zenoh-version) || '' }}
+          toolchain: "1.85.0"
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
   builds:


### PR DESCRIPTION
Once https://github.com/eclipse-zenoh/ci/pull/332 is merged, this one can be merged as well. Fixes https://github.com/eclipse-zenoh/zenoh-dissector/actions/runs/15547337338/job/43771268582