### PR TITLE
fix(zids): guard against null conversation state in update_zid_fields

### DIFF
--- a/zenoh-dissector/src/lib.rs
+++ b/zenoh-dissector/src/lib.rs
@@ -486,6 +486,9 @@ unsafe fn update_zid_fields(
     tree_args: &TreeArgs,
 ) {
     let conv_state = conversation_state(pinfo);
+    if conv_state.is_null() {
+        return;
+    }
 
     if let Some(src) = (*conv_state).source(pinfo) {
         epan_sys::proto_tree_add_string(


### PR DESCRIPTION
## Summary

Guard against null conversation state in `update_zid_fields`.

## Key Changes

- Add null check before dereferencing the pointer returned by `conversation_state()` — it returns `null_mut()` for mid-stream captures and UDP sessions without a prior InitSyn/InitAck exchange
- Early return instead of undefined behaviour

## Breaking Changes

None