### PR TITLE
ci: add workflow_dispatch workflow to regenerate epan-sys bindings

### DIFF
--- a/.github/workflows/regen-bindings.yml
+++ b/.github/workflows/regen-bindings.yml
@@ -1,0 +1,120 @@
+name: Regenerate Bindings
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  regen:
+    name: Regenerate bindings on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux
+            output: epan-sys/bindings.rs
+          - os: windows-2022
+            platform: windows
+            output: epan-sys/bindings_windows.rs
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hustcer/setup-nu@v3
+        with:
+          version: "0.100"
+
+      - name: Extract Wireshark version from Cargo.toml
+        id: wireshark-version
+        shell: nu {0}
+        run: |
+          let version = (open Cargo.toml | get workspace.metadata.wireshark_version)
+          $"version=($version)" | save --append $env.GITHUB_OUTPUT
+
+      - name: Install Wireshark (Ubuntu)
+        if: matrix.platform == 'linux'
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:wireshark-dev/stable-staging
+          sudo apt install -y wireshark-dev
+
+      - name: Install Wireshark dependencies (Windows)
+        if: matrix.platform == 'windows'
+        shell: nu {0}
+        run: |
+          let installed = (choco list -l -r --id-only | lines)
+          let install_list = ["xsltproc", "nsis", "winflexbison3", "cmake", "7zip"]
+
+          for pkg in $install_list {
+            if $pkg not-in $installed {
+              choco install -y --force --no-progress $pkg
+            }
+          }
+
+          choco install -y --no-progress wireshark --version $"${{ steps.wireshark-version.outputs.version }}.0"
+
+      - name: Enable long path support (Windows)
+        if: matrix.platform == 'windows'
+        run: |
+          powershell -Command "
+          New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1 -Force
+          "
+
+      - name: Build Wireshark from source (Windows)
+        if: matrix.platform == 'windows'
+        shell: powershell
+        run: |
+          & .\epan-sys\scripts\build.ps1 -WiresharkVersion "${{ steps.wireshark-version.outputs.version }}" -BuildConfig "Release"
+
+      - name: Install bindgen-cli
+        run: cargo install bindgen-cli --locked
+
+      - name: Regenerate bindings
+        run: cargo build -p epan-sys -F bindgen
+        env:
+          WIRESHARK_LIB_DIR: ${{ matrix.platform == 'windows' && 'C:\\wsbuild\\build\\run\\Release' || '' }}
+
+      - name: Upload bindings artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-${{ matrix.platform }}
+          path: ${{ matrix.output }}
+
+  commit:
+    name: Commit regenerated bindings
+    runs-on: ubuntu-latest
+    needs: regen
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Download Linux bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-linux
+          path: epan-sys/
+
+      - name: Download Windows bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-windows
+          path: epan-sys/
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add epan-sys/bindings.rs epan-sys/bindings_windows.rs
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: regenerate epan-sys bindings"
+          git push

--- a/.github/workflows/regen-bindings.yml
+++ b/.github/workflows/regen-bindings.yml
@@ -86,12 +86,13 @@ jobs:
           name: bindings-${{ matrix.platform }}
           path: ${{ matrix.output }}
 
-  commit:
-    name: Commit regenerated bindings
+  pr:
+    name: Open PR with regenerated bindings
     runs-on: ubuntu-latest
     needs: regen
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -110,11 +111,17 @@ jobs:
           name: bindings-windows
           path: epan-sys/
 
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add epan-sys/bindings.rs epan-sys/bindings_windows.rs
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: regenerate epan-sys bindings"
-          git push
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: regenerate epan-sys bindings"
+          branch: chore/regen-bindings
+          title: "chore: regenerate epan-sys bindings"
+          body: |
+            Automated regeneration of `epan-sys` FFI bindings triggered by @${{ github.actor }}.
+
+            - `epan-sys/bindings.rs` — regenerated on Ubuntu 24.04
+            - `epan-sys/bindings_windows.rs` — regenerated on Windows 2022
+
+            Triggered from: `${{ github.ref_name }}`
+          delete-branch: true

--- a/.github/workflows/regen-bindings.yml
+++ b/.github/workflows/regen-bindings.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           sudo apt install -y software-properties-common
           sudo add-apt-repository -y ppa:wireshark-dev/stable-staging
-          sudo apt install -y wireshark-dev
+          sudo apt install -y wireshark-dev=${{ steps.wireshark-version.outputs.version }}-*
 
       - name: Install Wireshark dependencies (Windows)
         if: matrix.platform == 'windows'
@@ -57,7 +57,7 @@ jobs:
             }
           }
 
-          choco install -y --no-progress wireshark --version $"${{ steps.wireshark-version.outputs.version }}.0"
+          choco install -y --no-progress wireshark --version $"${{ steps.wireshark-version.outputs.version }}"
 
       - name: Enable long path support (Windows)
         if: matrix.platform == 'windows'
@@ -75,10 +75,15 @@ jobs:
       - name: Install bindgen-cli
         run: cargo install bindgen-cli --locked
 
-      - name: Regenerate bindings
+      - name: Regenerate bindings (Linux)
+        if: matrix.platform == 'linux'
+        run: cargo build -p epan-sys -F bindgen
+
+      - name: Regenerate bindings (Windows)
+        if: matrix.platform == 'windows'
         run: cargo build -p epan-sys -F bindgen
         env:
-          WIRESHARK_LIB_DIR: ${{ matrix.platform == 'windows' && 'C:\\wsbuild\\build\\run\\Release' || '' }}
+          WIRESHARK_LIB_DIR: C:\wsbuild\build\run\Release
 
       - name: Upload bindings artifact
         uses: actions/upload-artifact@v4
@@ -115,7 +120,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore: regenerate epan-sys bindings"
-          branch: chore/regen-bindings
+          branch: chore/regen-bindings-${{ github.run_id }}
           title: "chore: regenerate epan-sys bindings"
           body: |
             Automated regeneration of `epan-sys` FFI bindings triggered by @${{ github.actor }}.


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow to regenerate `epan-sys` FFI bindings whenever `wrapper.h` changes
- Runs parallel jobs on Ubuntu 24.04 (for `bindings.rs`) and Windows 2022 (for `bindings_windows.rs`)
- Opens a PR with the regenerated files for review rather than pushing directly

## Key Changes
- `.github/workflows/regen-bindings.yml`: new workflow — regen jobs on both platforms, then opens a PR via `peter-evans/create-pull-request`

## Breaking Changes
None