### PR TITLE
Revert changes related to project content and dependency licensing

### DIFF
--- a/epan-sys/Cargo.toml
+++ b/epan-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "epan-sys"
 version = { workspace = true }
 edition = "2021"
-license = "MIT OR Apache-2.0"
+license = "GPL-2.0-or-later"
 description = "FFI Bindings to Wireshark's epan module"
 links = "wireshark"
 keywords = ["wireshark", "ffi"]

--- a/epan-sys/Cargo.toml
+++ b/epan-sys/Cargo.toml
@@ -1,16 +1,3 @@
-#
-# Copyright (c) 2026 ZettaScale Technology
-#
-# This program and the accompanying materials are made available under the
-# terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-# which is available at https://www.apache.org/licenses/LICENSE-2.0.
-#
-# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-#
-# Contributors:
-#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
 [package]
 name = "epan-sys"
 version = { workspace = true }

--- a/epan-sys/scripts/build.ps1
+++ b/epan-sys/scripts/build.ps1
@@ -1,16 +1,3 @@
-#
-# Copyright (c) 2026 ZettaScale Technology
-#
-# This program and the accompanying materials are made available under the
-# terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-# which is available at https://www.apache.org/licenses/LICENSE-2.0.
-#
-# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-#
-# Contributors:
-#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
 param(
     [string]$WiresharkVersion = "4.6.0",
     [string]$BuildConfig = "Debug"

--- a/epan-sys/src/lib.rs
+++ b/epan-sys/src/lib.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 // Suppress the warnings
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]

--- a/epan-sys/wrapper.h
+++ b/epan-sys/wrapper.h
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 #ifndef EPAN_SYS
 #define EPAN_SYS
 

--- a/zenoh-dissector/Cargo.toml
+++ b/zenoh-dissector/Cargo.toml
@@ -1,16 +1,3 @@
-#
-# Copyright (c) 2026 ZettaScale Technology
-#
-# This program and the accompanying materials are made available under the
-# terms of the Eclipse Public License 2.0 which is available at
-# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-# which is available at https://www.apache.org/licenses/LICENSE-2.0.
-#
-# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-#
-# Contributors:
-#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-#
 [package]
 name = "zenoh-dissector"
 version = { workspace = true }

--- a/zenoh-dissector/build.rs
+++ b/zenoh-dissector/build.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use cargo_metadata::MetadataCommand;
 use std::{env, ffi::CString, fs, path::Path};
 

--- a/zenoh-dissector/src/conversation.rs
+++ b/zenoh-dissector/src/conversation.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use std::{
     ffi::{c_char, CStr, CString},
     mem, ptr,

--- a/zenoh-dissector/src/header_field.rs
+++ b/zenoh-dissector/src/header_field.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]

--- a/zenoh-dissector/src/lib.rs
+++ b/zenoh-dissector/src/lib.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use anyhow::Result;
 use header_field::{FieldKind, Registration};
 use std::{cell::RefCell, collections::HashMap, ffi::CString, slice, sync::LazyLock};

--- a/zenoh-dissector/src/macros.rs
+++ b/zenoh-dissector/src/macros.rs
@@ -1,17 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-
 macro_rules! impl_for_enum {
     (
         enum $enum_name:ident {

--- a/zenoh-dissector/src/tree.rs
+++ b/zenoh-dissector/src/tree.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use anyhow::{bail, Result};
 use std::{collections::HashMap, ffi::CString};
 

--- a/zenoh-dissector/src/utils.rs
+++ b/zenoh-dissector/src/utils.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use anyhow::Result;
 use std::{
     error::Error,

--- a/zenoh-dissector/src/wireshark.rs
+++ b/zenoh-dissector/src/wireshark.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use crate::{header_field::FieldKind, utils::leak_nul_terminated_str};
 use anyhow::Result;
 use epan_sys::{field_display_e, ftenum};

--- a/zenoh-dissector/src/ws_log.rs
+++ b/zenoh-dissector/src/ws_log.rs
@@ -1,17 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
-
 //! Wireshark-native logging.
 //!
 //! See [ws_log_defs.h] for a description of [`epan_sys::ws_log_level`].

--- a/zenoh-dissector/src/zenoh_impl.rs
+++ b/zenoh-dissector/src/zenoh_impl.rs
@@ -1,16 +1,3 @@
-//
-// Copyright (c) 2026 ZettaScale Technology
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
-// which is available at https://www.apache.org/licenses/LICENSE-2.0.
-//
-// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
-//
-// Contributors:
-//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
-//
 use crate::header_field::*;
 use crate::macros::{impl_for_enum, impl_for_struct};
 use crate::tree::*;


### PR DESCRIPTION
This patch corrects statements on the status of (1) `libwireshark`'s license and (2) the license of the dissector as a derived work.
