### PR TITLE
chore: fix clippy for 1.97.1

### DIFF
--- a/zenoh-dissector/src/tree.rs
+++ b/zenoh-dissector/src/tree.rs
@@ -21,7 +21,7 @@ impl TreeArgs<'_> {
         if let Some(hf) = self.hf_map.get(key) {
             Ok(*hf)
         } else {
-            bail!("{key} not found in {:?}", &self.hf_map)
+            bail!("{key} not found in {:?}", self.hf_map)
         }
     }
 
@@ -29,7 +29,7 @@ impl TreeArgs<'_> {
         if let Some(st) = self.st_map.get(key) {
             Ok(*st)
         } else {
-            bail!("{key} not found in {:?}", &self.st_map)
+            bail!("{key} not found in {:?}", self.st_map)
         }
     }
 


### PR DESCRIPTION
Should unblock PR #149 clippy errors updating the `rust-toolchain.toml` to use 1.97.1