### PR TITLE
chore: don't pass toolchain to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,6 @@ jobs:
           bump-deps-pattern: ${{ inputs.zenoh-version && 'zenoh.*' || '' }}
           bump-deps-version: ${{ inputs.zenoh-version }}
           bump-deps-branch: ${{ inputs.zenoh-version && format('release/{0}', inputs.zenoh-version) || '' }}
-          toolchain: "1.85.0"
           github-token: ${{ secrets.BOT_TOKEN_WORKFLOW }}
 
   builds:


### PR DESCRIPTION
Remove toolchain from release workflow so it bump-crates action can use rust-toolchain.toml instead.

Depends on https://github.com/eclipse-zenoh/ci/pull/461
Fix https://github.com/eclipse-zenoh/zenoh-dissector/actions/runs/30410806867/job/90446206967